### PR TITLE
[fix] allow svgs to be on an another domain

### DIFF
--- a/src/vue-svg-filler.js
+++ b/src/vue-svg-filler.js
@@ -70,7 +70,7 @@ export default {
   methods: {
     createSvgElement () {
       const dir = window.location.origin
-      const source = this.path.substring(0, 1) === '/' ? `${dir}${this.path}` : `${dir}/${this.path}`
+      const source = this.path.match(/^http(s?):\/\//) ? this.path : (this.path.substring(0, 1) === '/' ? `${dir}${this.path}` : `${dir}/${this.path}`)
       const request = new XMLHttpRequest()
       request.open('GET', source, true)
       request.onload = () => {


### PR DESCRIPTION
your library assume images are stored under the same domain than the current page. In my case I have some images stored on a CDN and I need to use the absolute url. 

My PR just test if the path starts with http:// ou https:// before prepending or not the window.location.origin